### PR TITLE
Fix issue preventing to create multiple namespaces with a list

### DIFF
--- a/chart/namespace/templates/namespace.yaml
+++ b/chart/namespace/templates/namespace.yaml
@@ -1,7 +1,7 @@
 {{- $annotations := .Values.annotations -}}
 {{- $labels := .Values.labels -}}
 {{- $helmResourcePolicy := .Values.helmResourcePolicy -}}
-{{- range $key := .Values.namespaces -}}
+{{- range $key := .Values.namespaces}}
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
There is no newline added between elements in the loop leading to this
kind of output:

```
    app.kubernetes.io/managed-by: Helm---
apiVersion: v1
kind: Namespace

```
Fixing this by removing the EOL character stripping in the range line.