### PR TITLE
update chart api version so that helm lint works with helm 3 fixes #2

### DIFF
--- a/chart/namespace/Chart.yaml
+++ b/chart/namespace/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: namespace
 description: A generic helm3 namespace chart
 type: application


### PR DESCRIPTION
I guess this PR would cause issues if merged for folks that use helm lint with helm 2.  Would it be possible to use git tags to help handle working with different api versions?